### PR TITLE
TypeScript: add types for the array methods (`map`, `filter`, etc)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on: pull_request
 

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -1,0 +1,40 @@
+name: Types
+
+on: pull_request
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check types
+        run: pnpm tsc packages/deepsignal/core/test/types.ts --noEmit || exit 1

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -16,8 +16,107 @@ type DeepSignalObject<T extends object> = {
 		: T[P];
 };
 
+// @ts-expect-error
+interface MyArray<T> extends Array<T> {
+	map: <U>(
+		callbackfn: (
+			value: DeepSignal<T>,
+			index: number,
+			array: DeepSignalArray<T[]>
+		) => U,
+		thisArg?: any
+	) => U[];
+	forEach: (
+		callbackfn: (
+			value: DeepSignal<T>,
+			index: number,
+			array: DeepSignalArray<T[]>
+		) => void,
+		thisArg?: any
+	) => void;
+	concat(...items: ConcatArray<T>[]): DeepSignalArray<T[]>;
+	concat(...items: (T | ConcatArray<T>)[]): DeepSignalArray<T[]>;
+	reverse(): DeepSignalArray<T[]>;
+	shift(): DeepSignal<T> | undefined;
+	slice(start?: number, end?: number): DeepSignalArray<T[]>;
+	splice(start: number, deleteCount?: number): DeepSignalArray<T[]>;
+	splice(
+		start: number,
+		deleteCount: number,
+		...items: T[]
+	): DeepSignalArray<T[]>;
+	filter<S extends T>(
+		predicate: (
+			value: DeepSignal<T>,
+			index: number,
+			array: DeepSignalArray<T[]>
+		) => value is DeepSignal<S>,
+		thisArg?: any
+	): DeepSignalArray<S[]>;
+	filter(
+		predicate: (
+			value: DeepSignal<T>,
+			index: number,
+			array: DeepSignalArray<T[]>
+		) => unknown,
+		thisArg?: any
+	): DeepSignalArray<T[]>;
+	reduce(
+		callbackfn: (
+			previousValue: DeepSignal<T>,
+			currentValue: DeepSignal<T>,
+			currentIndex: number,
+			array: DeepSignalArray<T[]>
+		) => T
+	): DeepSignal<T>;
+	reduce(
+		callbackfn: (
+			previousValue: DeepSignal<T>,
+			currentValue: DeepSignal<T>,
+			currentIndex: number,
+			array: DeepSignalArray<T[]>
+		) => DeepSignal<T>,
+		initialValue: T
+	): DeepSignal<T>;
+	reduce<U>(
+		callbackfn: (
+			previousValue: U,
+			currentValue: DeepSignal<T>,
+			currentIndex: number,
+			array: DeepSignalArray<T[]>
+		) => U,
+		initialValue: U
+	): U;
+	reduceRight(
+		callbackfn: (
+			previousValue: DeepSignal<T>,
+			currentValue: DeepSignal<T>,
+			currentIndex: number,
+			array: DeepSignalArray<T[]>
+		) => T
+	): DeepSignal<T>;
+	reduceRight(
+		callbackfn: (
+			// previousValue: DeepSignal<T>, // Fail on purpose to test GH action
+			previousValue: T,
+			currentValue: DeepSignal<T>,
+			currentIndex: number,
+			array: DeepSignalArray<T[]>
+		) => DeepSignal<T>,
+		initialValue: T
+	): DeepSignal<T>;
+	reduceRight<U>(
+		callbackfn: (
+			previousValue: U,
+			currentValue: DeepSignal<T>,
+			currentIndex: number,
+			array: DeepSignalArray<T[]>
+		) => U,
+		initialValue: U
+	): U;
+}
 type ArrayType<T> = T extends Array<infer I> ? I : T;
-type DeepSignalArray<T> = Array<ArrayType<T>> & {
+type DeepSignalArray<T> = MyArray<ArrayType<T>> & {
 	[key: number]: DeepSignal<ArrayType<T>>;
 	$?: { [key: number]: Signal<ArrayType<T>> };
 	$length?: Signal<number>;

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -121,6 +121,12 @@ describe("deepsignal/core", () => {
 			store.switch = "b";
 			expect(store.aOrB.$data!.value).to.equal("b");
 		});
+
+		it("should return signals from array iterators", () => {
+			const store = deepSignal([{ a: 1 }, { a: 2 }]);
+			const signals = store.map(item => item.$a!.value);
+			expect(signals).to.deep.equal([1, 2]);
+		});
 	});
 
 	describe("set", () => {

--- a/packages/deepsignal/core/test/types.ts
+++ b/packages/deepsignal/core/test/types.ts
@@ -1,0 +1,42 @@
+import { Signal } from "@preact/signals-core";
+import { deepSignal, peek } from "../src";
+
+// Arrays.
+const array = deepSignal([{ a: 1 }, { a: 2 }]);
+const a1: number = array.length;
+const a2: Signal<number> = array.$length!;
+const a3: number = peek(array, "length");
+const a4: { a: number } = array[0];
+const a5: Signal<{ a: number }> = array.$![0];
+const a6: { a: number } = peek(array, 0);
+const a7: number = array[0].a;
+const a8: Signal<number> = array[0].$a!;
+const a9: number = peek(array, 0).a;
+const a10: number[] = array.map(item => item.a);
+const a11: Signal<number>[] = array.map(item => item.$a!);
+const a12 = array.forEach(item => item.$a);
+const a13: Signal<number> = array.concat([{ a: 3 }])[0].$a!;
+const a14: Signal<number> = array.concat({ a: 3 })[0].$a!;
+const a15: Signal<number> = array.reverse()[0].$a!;
+const a16: Signal<number> = array.shift()!.$a!;
+const a17: Signal<number> = array.slice(0, 1)[0].$a!;
+const a18: Signal<number> = array.sort()[0].$a!;
+const a19: Signal<number> = array.splice(0, 1)[0].$a!;
+const a20: Signal<number> = array.splice(0, 1, { a: 3 })[0].$a!;
+const a21: Signal<number> = array.filter(item => !item.$a!)[0].$a!;
+const a22: Signal<number> = array.reduce((prev, curr) =>
+	prev.$a!.value > curr.$a!.value ? prev : curr
+).$a!;
+const a23: number = array.reduce((prev, curr) => prev + curr.$a!.value, 0);
+const a24: Signal<number> = array.reduce(
+	(prev, curr) => (prev.$a!.value > curr.$a!.value ? prev : curr),
+	array[0]
+).$a!;
+const a25: Signal<number> = array.reduceRight((prev, curr) =>
+	prev.$a!.value > curr.$a!.value ? prev : curr
+).$a!;
+const a26: number = array.reduceRight((prev, curr) => prev + curr.$a!.value, 0);
+const a27: Signal<number> = array.reduceRight(
+	(prev, curr) => (prev.$a!.value > curr.$a!.value ? prev : curr),
+	{ a: 3 }
+).$a!;


### PR DESCRIPTION
## What 

TypeScript: add types for the array methods (`map`, `filter`, etc).

## Why

Because if not, the `$` prefix can't be used on their callbacks or resulting arrays.

## How

With a new interface that extends `Array` and adds the new method types.

---

It's still a draft. I want to move all the types to a new file and test a GH action that runs `tsc` against a test tile.