### PR TITLE
Support for regular functions

### DIFF
--- a/.changeset/wise-shirts-applaud.md
+++ b/.changeset/wise-shirts-applaud.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Support regular functions inside the deep signal.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
 - **Stable references**: `deepsignal` uses stable references, which means that the same `Proxy` instances will be returned for the same objects so they can exist in different places of the data structure, just like regular JavaScript objects.
 - **Automatic derived state**: getters are automatically converted to computeds instead of signals.
 - **TypeScript support**: `deepsignal` is written in TypeScript and includes type definitions, so you can use it seamlessly with your TypeScript projects, including access to the signal value through the prefix `state.$prop`.
+- **State management**: `deepsignal` can be used as a state manager, including state and actions in the same object.
 
 The most important feature is that **it just works**. You don't need to do anything special. Just create an object, mutate it normally and all your components will know when they need to rerender.
 
@@ -61,7 +62,7 @@ import { deepSignal } from "deepsignal";
 const state = deepSignal({});
 ```
 
-#### Usage without Preact
+#### Without Preact
 
 If you are using the library with `@preact/signals-core`, you should use the `deepsignal/core` import.
 
@@ -116,6 +117,30 @@ function Counter() {
 	return (
 		<button onClick={() => (state.count += 1)}>
 			{state.$count} x 2 = {state.$double}
+		</button>
+	);
+}
+```
+
+You can also add actions inside the deep signal and use it as a state manager.
+
+```js
+import { deepSignal } from "deepsignal";
+
+const store = deepSignal({
+	count: 0,
+	get double() {
+		return store.count * 2;
+	},
+	inc: () => {
+		store.count += 1;
+	},
+});
+
+function Counter() {
+	return (
+		<button onClick={store.inc}>
+			{store.$count} x 2 = {store.$double}
 		</button>
 	);
 }

--- a/packages/deepsignal/core/test/types.ts
+++ b/packages/deepsignal/core/test/types.ts
@@ -40,3 +40,26 @@ const a27: Signal<number> = array.reduceRight(
 	(prev, curr) => (prev.$a!.value > curr.$a!.value ? prev : curr),
 	{ a: 3 }
 ).$a!;
+// @ts-expect-error
+array.$0;
+
+// Normal functions.
+const store = deepSignal({
+	value: 1,
+	isBigger: (newValue: number): boolean => store.value > newValue,
+	sum(newValue: number): number {
+		return store.value + newValue;
+	},
+	valueSignal: (): Signal<number> => store.$value!,
+	nested: {
+		toString: (): string => `${store.value}`,
+	},
+});
+const s1: boolean = store.isBigger(2);
+const s2: number = store.sum(2);
+const s3: Signal<number> = store.valueSignal();
+const s4: string = store.toString();
+// @ts-expect-error
+store.isBigger!.value();
+// @ts-expect-error
+store.nested.$toString!.value();


### PR DESCRIPTION
## What

Support for regular functions.

## Why

To be able to use a deep signal as a state manager, like:

```js
const store = deepSignal({
  counter: 0,
  inc: () => (store.counter += 1),
  dec: () => (store.counter -= 1),
});
```

## How

I fixed the types and avoided wrapping regular functions with signals.