### PR TITLE
Fix core exports

### DIFF
--- a/.changeset/famous-shrimps-vanish.md
+++ b/.changeset/famous-shrimps-vanish.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Fix `deepsignal/core` exports.

--- a/packages/deepsignal/package.json
+++ b/packages/deepsignal/package.json
@@ -26,10 +26,10 @@
 			"require": "./dist/deepsignal.js"
 		},
 		"./core": {
-			"types": "./preact/dist/deepsignal-core.d.ts",
-			"browser": "./preact/dist/deepsignal-core.module.js",
-			"import": "./preact/dist/deepsignal-core.mjs",
-			"require": "./preact/dist/deepsignal-core.js"
+			"types": "./core/dist/deepsignal-core.d.ts",
+			"browser": "./core/dist/deepsignal-core.module.js",
+			"import": "./core/dist/deepsignal-core.mjs",
+			"require": "./core/dist/deepsignal-core.js"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
## What

Fix `deepsignal/core` exports because they pointed to the wrong folder.

## Why

Because it's not working: https://stackblitz.com/edit/react-ts-cshxev?file=App.tsx,index.html

## How

Changing `package.json` `"exports"` property.