### PR TITLE
Allow signal assignments

### DIFF
--- a/.changeset/sweet-rice-repair.md
+++ b/.changeset/sweet-rice-repair.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": minor
+---
+
+Allow replacing signals with a new signal instance, e.g., `store.$a = signal(1)`.

--- a/.changeset/sweet-rice-repair.md
+++ b/.changeset/sweet-rice-repair.md
@@ -2,4 +2,4 @@
 "deepsignal": minor
 ---
 
-Allow replacing signals with a new signal instance, e.g., `store.$a = signal(1)`.
+Allow replacing signals with a new signal instance, e.g., `state.$prop = signal(1)`.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
     - [`deepSignal`](#deepsignal)
     - [`get prop() { ... }`](#get-prop---)
     - [`state.$prop`](#stateprop)
-    - [`state.$prop = signal(value)`](#stateprop--signalvalue)
     - [`array.$[index]`](#arrayindex)
     - [`array.$length`](#arraylength)
     - [`peek(state, "prop")`](#peekstate-prop)
+    - [`state.$prop = signal(value)`](#stateprop--signalvalue)
     - [`useDeepSignal`](#usedeepsignal)
   - [When do you need access to signals?](#when-do-you-need-access-to-signals)
     - [Passing the value of a signal directly to JSX](#passing-the-value-of-a-signal-directly-to-jsx)
@@ -226,23 +226,6 @@ state.$counter.subscribe(console.log);
 state.counter = 1;
 ```
 
-### `state.$prop = signal(value)`
-
-You can modify the underlying signal of an object's property doing an assignment to the `$`-prefixed name.
-
-```js
-const state = deepSignal({ counter: 0 });
-
-// Runs the first time, read value from signal, logs: 0.
-state.$counter.subscribe(console.log);
-
-// Replace the signal with a new one.
-state.$counter = signal(10);
-
-// The subscription doesn't run this time; it's a different signal!
-state.counter = 1;
-```
-
 ### `array.$[index]`
 
 You can access the underlying signal of an array's item by using the `$` prefix, like so: `state.$[index]`.
@@ -294,6 +277,23 @@ effect(() => {
 Note that you should only use `peek()` if you really need it. Reading a signal's value via `state.prop` is the preferred way in most scenarios.
 
 _For primitive values, you can get away with using `store.$prop.peek()` instead of `peek(state, "prop")`. But in `deepsignal`, the underlying signals store the proxies, not the object. That means it's not safe to use `state.$prop.peek().nestedProp` if `prop` is an object. You should use `peek(state, "prop").nestedProp` instead._
+
+### `state.$prop = signal(value)`
+
+You can modify the underlying signal of an object's property doing an assignment to the `$`-prefixed name.
+
+```js
+const state = deepSignal({ counter: 0 });
+
+// Runs the first time, read value from signal, logs: 0.
+state.$counter.subscribe(console.log);
+
+// Replace the signal with a new one.
+state.$counter = signal(10);
+
+// The subscription doesn't run this time; it's a different signal!
+state.counter = 1;
+```
 
 ### `useDeepSignal`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
     - [`deepSignal`](#deepsignal)
     - [`get prop() { ... }`](#get-prop---)
     - [`state.$prop`](#stateprop)
-    - [`set $prop() { ... }`](#set-prop---)
+    - [`state.$prop = signal(value)`](#stateprop--signalvalue)
     - [`array.$[index]`](#arrayindex)
     - [`array.$length`](#arraylength)
     - [`peek(state, "prop")`](#peekstate-prop)
@@ -226,7 +226,7 @@ state.$counter.subscribe(console.log);
 state.counter = 1;
 ```
 
-### `set $prop() { ... }`
+### `state.$prop = signal(value)`
 
 You can modify the underlying signal of an object's property doing an assignment to the `$`-prefixed name.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
     - [`deepSignal`](#deepsignal)
     - [`get prop() { ... }`](#get-prop---)
     - [`state.$prop`](#stateprop)
+    - [`set $prop() { ... }`](#set-prop---)
     - [`array.$[index]`](#arrayindex)
     - [`array.$length`](#arraylength)
     - [`peek(state, "prop")`](#peekstate-prop)
@@ -222,6 +223,23 @@ const state = deepSignal({ counter: 0 });
 state.$counter.subscribe(console.log);
 
 // Mutates the underlying signal. The subscription runs again, logs: 1.
+state.counter = 1;
+```
+
+### `set $prop() { ... }`
+
+You can modify the underlying signal of an object's property doing an assignment to the `$`-prefixed name.
+
+```js
+const state = deepSignal({ counter: 0 });
+
+// Runs the first time, read value from signal, logs: 0.
+state.$counter.subscribe(console.log);
+
+// Replace the signal with a new one.
+state.$counter = signal(10);
+
+// The subscription doesn't run this time; it's a different signal!
 state.counter = 1;
 ```
 

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { Signal, effect } from "@preact/signals-core";
+import { Signal, effect, signal } from "@preact/signals-core";
 import { deepSignal, peek } from "deepsignal/core";
 
 describe("deepsignal/core", () => {
@@ -212,6 +212,22 @@ describe("deepsignal/core", () => {
 		it("should throw when trying to mutate the signals array", () => {
 			expect(() => ((store.array.$ as any)[0] = 2)).to.throw();
 		});
+
+		it("should allow singal assignments", () => {
+			const store = deepSignal<{ ss?: string }>({});
+			const ss = signal('value');
+
+			store.$ss = ss;
+
+			expect(store.ss).to.equal('value');
+			expect(store.$ss).to.equal(ss);
+
+			store.ss = 'newValue';
+
+			expect(ss.value).to.equal('newValue');
+			expect(store.ss).to.equal('newValue');
+			expect(store.$ss).to.equal(ss);
+		})
 	});
 
 	describe("computations", () => {

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -213,21 +213,21 @@ describe("deepsignal/core", () => {
 			expect(() => ((store.array.$ as any)[0] = 2)).to.throw();
 		});
 
-		it("should allow singal assignments", () => {
-			const store = deepSignal<{ ss?: string }>({});
-			const ss = signal('value');
+		it("should allow signal assignments", () => {
+			const store = deepSignal<{ a?: number }>({});
+			const a = signal(1);
 
-			store.$ss = ss;
+			store.$a = a;
 
-			expect(store.ss).to.equal('value');
-			expect(store.$ss).to.equal(ss);
+			expect(store.a).to.equal(1);
+			expect(store.$a).to.equal(a);
 
-			store.ss = 'newValue';
+			store.a = 2;
 
-			expect(ss.value).to.equal('newValue');
-			expect(store.ss).to.equal('newValue');
-			expect(store.$ss).to.equal(ss);
-		})
+			expect(a.value).to.equal(2);
+			expect(store.a).to.equal(2);
+			expect(store.$a).to.equal(a);
+		});
 	});
 
 	describe("computations", () => {


### PR DESCRIPTION
_Coauthored with @luisherranz_

## What

Allow setting a signal directly to the `$`-prefixed attributes. For example:

```js
const state = deepSignal({ counter: 0 });

// Runs the first time, read value from signal, logs: 0.
state.$counter.subscribe(console.log);

// Replace the signal with a new one.
state.$counter = signal(10);

// The subscription doesn't run this time; it's a different signal!
state.counter = 1;
```

## Why

Useful in some cases where you may need to modify a specific part of a given `deepSignal` instance. 

## How

Modifying the `set` handler to replace the signal under the specified `$key` with the passed signal. 