### PR TITLE
Add support for deleting properties

### DIFF
--- a/.changeset/pink-files-float.md
+++ b/.changeset/pink-files-float.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Add support for deleting object properties, like `delete store.a`.

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@babel/core": "^7.19.1",
+		"@babel/plugin-transform-typescript": "^7.19.1",
 		"@babel/preset-env": "^7.19.1",
 		"@babel/preset-react": "^7.18.6",
 		"@babel/preset-typescript": "^7.18.6",
-		"@babel/plugin-transform-typescript": "^7.19.1",
 		"@changesets/changelog-github": "^0.4.6",
 		"@changesets/cli": "^2.24.2",
 		"@types/chai": "^4.3.3",

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -104,14 +104,9 @@ const objectHandlers = {
 	},
 	deleteProperty(target: object, key: string): boolean {
 		if (key[0] === "$") throwOnMutation();
-		const result = Reflect.deleteProperty(target, key);
-		if (!objToProxy.has(target))
-			objToProxy.set(target, createProxy(target, objectHandlers));
-		const proxy = objToProxy.get(target);
-		if (!proxyToSignals.has(proxy)) return result;
-		const signals = proxyToSignals.get(proxy);
-		if (signals.has(key)) signals.get(key).value = undefined;
-		return result;
+		const signals = proxyToSignals.get(objToProxy.get(target));
+		if (signals && signals.has(key)) signals.get(key).value = undefined;
+		return Reflect.deleteProperty(target, key);
 	},
 };
 


### PR DESCRIPTION
## What

Add support for deleting properties like `delete store.a`.

## Why

Because it's another type of mutation that can be applied to plain JS objects, so it should be supported.

## How

Add the `deleteProperty` handler.

_I branched this PR on top of [luisherranz/deepsignal#20](https://github.com/luisherranz/deepsignal/pull/20), so we should wait until that one is merged to merge this one._