### PR TITLE
Add support for the `ownKeys` trap

### DIFF
--- a/.changeset/brave-meals-end.md
+++ b/.changeset/brave-meals-end.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Add support for the `ownKeys` trap, which is used with `for..in`, `getOwnPropertyNames` or `Object.keys/values/entries`.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
 ---
 
 - Try it on Stackblitz
-  - [Preact](https://stackblitz.com/edit/vitejs-vite-6qfchy?file=src%2Fmain.jsx) 
-  - [Preact & TypeScript](https://stackblitz.com/edit/vitejs-vite-hktyyf?file=src%2Fmain.tsx) 
-  - [React](https://stackblitz.com/edit/vitejs-vite-zoh464?file=src%2Fmain.jsx) 
-  - [React & TypeScript](https://stackblitz.com/edit/vitejs-vite-r2stgq?file=src%2Fmain.tsx) 
+  - [Preact](https://stackblitz.com/edit/vitejs-vite-6qfchy?file=src%2Fmain.jsx)
+  - [Preact & TypeScript](https://stackblitz.com/edit/vitejs-vite-hktyyf?file=src%2Fmain.tsx)
+  - [React](https://stackblitz.com/edit/vitejs-vite-zoh464?file=src%2Fmain.jsx)
+  - [React & TypeScript](https://stackblitz.com/edit/vitejs-vite-r2stgq?file=src%2Fmain.tsx)
 - Or on Codesandbox
-  - [Preact](https://codesandbox.io/s/deepsignal-demo-hv1i1p) 
-  - [Preact & TypeScript](https://codesandbox.io/s/deepsignal-demo-typescript-os7ox0?file=/src/index.tsx) 
-  - [React](https://codesandbox.io/s/deepsignal-demo-react-fupt1x?file=/src/index.js) 
+  - [Preact](https://codesandbox.io/s/deepsignal-demo-hv1i1p)
+  - [Preact & TypeScript](https://codesandbox.io/s/deepsignal-demo-typescript-os7ox0?file=/src/index.tsx)
+  - [React](https://codesandbox.io/s/deepsignal-demo-react-fupt1x?file=/src/index.js)
   - [React & TypeScript](https://codesandbox.io/s/deepsignal-demo-react-typescript-jszfjw?file=/src/index.tsx)
 
 ---
@@ -425,6 +425,18 @@ console.log(array.$![0].value); // 1
 ```
 
 Note that here the position of the non-null assertion operator changes because `array.$` is an object in itself.
+
+### DeepSignal and RevertDeepSignal types
+
+DeepSignal exports two types, one to convert from a raw state/store to a `deepSignal` instance, and other to revert from a `deepSignal` instance back to the raw store.
+
+These types are handy when manual casting is needed, like when you try to use `Object.values()`:
+
+```ts
+import type { RevertDeepSignal } from "deepsignal";
+
+const values = Object.values(store as RevertDeepSignal<typeof store>);
+```
 
 ## License
 

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -97,9 +97,8 @@ const objectHandlers = {
 			}
 			const isNew = !(fullKey in target);
 			const result = Reflect.set(target, fullKey, val, receiver);
-			if (!signals.has(fullKey)) {
-				signals.set(fullKey, signal(internal));
-			} else signals.get(fullKey).value = internal;
+			if (!signals.has(fullKey)) signals.set(fullKey, signal(internal));
+			else signals.get(fullKey).value = internal;
 			if (isNew && objToIterable.has(target)) objToIterable.get(target).value++;
 			if (Array.isArray(target) && signals.has("length"))
 				signals.get("length").value = target.length;

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -109,10 +109,8 @@ const objectHandlers = {
 		if (key[0] === "$") throwOnMutation();
 		const signals = proxyToSignals.get(objToProxy.get(target));
 		const result = Reflect.deleteProperty(target, key);
-		if (signals && signals.has(key)) {
-			signals.get(key).value = undefined;
-			objToIterable.has(target) && objToIterable.get(target).value++;
-		}
+		if (signals && signals.has(key)) signals.get(key).value = undefined;
+		objToIterable.has(target) && objToIterable.get(target).value++;
 		return result;
 	},
 	ownKeys(target: object): (string | symbol)[] {

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -272,7 +272,7 @@ type FilterSignals<K> = K extends `$${infer P}` ? never : K;
 type RevertDeepSignalObject<T> = Pick<T, FilterSignals<keyof T>>;
 type RevertDeepSignalArray<T> = Omit<T, "$" | "$length">;
 
-type RevertDeepSignal<T> = T extends Array<unknown>
+export type RevertDeepSignal<T> = T extends Array<unknown>
 	? RevertDeepSignalArray<T>
 	: T extends object
 	? RevertDeepSignalObject<T>

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -95,11 +95,12 @@ const objectHandlers = {
 					objToProxy.set(val, createProxy(val, objectHandlers));
 				internal = objToProxy.get(val);
 			}
+			const isNew = !(fullKey in target);
 			const result = Reflect.set(target, fullKey, val, receiver);
 			if (!signals.has(fullKey)) {
 				signals.set(fullKey, signal(internal));
-				objToIterable.has(target) && objToIterable.get(target).value++;
 			} else signals.get(fullKey).value = internal;
+			if (isNew && objToIterable.has(target)) objToIterable.get(target).value++;
 			if (Array.isArray(target) && signals.has("length"))
 				signals.get("length").value = target.length;
 			return result;

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -1,5 +1,6 @@
 import { Signal, effect, signal } from "@preact/signals-core";
 import { deepSignal, peek } from "deepsignal/core";
+import type { RevertDeepSignal } from "deepsignal/core";
 
 type Store = {
 	a?: number;
@@ -428,16 +429,20 @@ describe("deepsignal/core", () => {
 
 			effect(() => {
 				values = 0;
-				Object.values(store as typeof state).forEach(value => {
-					values += value;
-				});
+				Object.values(store as RevertDeepSignal<typeof store>).forEach(
+					value => {
+						values += value;
+					}
+				);
 			});
 
 			effect(() => {
 				entries = 0;
-				Object.entries(store as typeof state).forEach(([_, value]) => {
-					entries += value;
-				});
+				Object.entries(store as RevertDeepSignal<typeof store>).forEach(
+					([_, value]) => {
+						entries += value;
+					}
+				);
 			});
 
 			expect(keys).to.equal(3);

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -371,38 +371,38 @@ describe("deepsignal/core", () => {
 
 	describe("computations", () => {
 		it("should subscribe to changes when an item is removed from the array", () => {
-			const store = deepSignal([1, 2, 3]);
+			const store = deepSignal([0, 0, 0]);
 			let sum = 0;
 
 			effect(() => {
 				sum = 0;
-				sum = store.reduce((sum, item) => sum + item, 0);
+				sum = store.reduce(sum => sum + 1, 0);
 			});
 
-			expect(sum).to.equal(6);
-			store.splice(2, 1);
 			expect(sum).to.equal(3);
+			store.splice(2, 1);
+			expect(sum).to.equal(2);
 		});
 
 		it("should subscribe to changes to for..in loops", () => {
-			const state: Record<string, number> = { a: 1, b: 2 };
+			const state: Record<string, number> = { a: 0, b: 0 };
 			const store = deepSignal(state);
 			let sum = 0;
 
 			effect(() => {
 				sum = 0;
-				for (const key in store) {
-					sum += store[key];
+				for (const _ in store) {
+					sum += 1;
 				}
 			});
 
+			expect(sum).to.equal(2);
+
+			store.c = 0;
 			expect(sum).to.equal(3);
 
-			store.c = 3;
-			expect(sum).to.equal(6);
-
 			delete store.a;
-			expect(sum).to.equal(5);
+			expect(sum).to.equal(2);
 		});
 
 		it("should subscribe to changes for Object.getOwnPropertyNames()", () => {
@@ -413,18 +413,18 @@ describe("deepsignal/core", () => {
 			effect(() => {
 				sum = 0;
 				const keys = Object.getOwnPropertyNames(store);
-				for (const key of keys) {
-					sum += store[key];
+				for (const _ of keys) {
+					sum += 1;
 				}
 			});
 
+			expect(sum).to.equal(2);
+
+			store.c = 0;
 			expect(sum).to.equal(3);
 
-			store.c = 3;
-			expect(sum).to.equal(6);
-
 			delete store.a;
-			expect(sum).to.equal(5);
+			expect(sum).to.equal(2);
 		});
 
 		it("should subscribe to changes to Object.keys/values/entries()", () => {
@@ -436,62 +436,56 @@ describe("deepsignal/core", () => {
 
 			effect(() => {
 				keys = 0;
-				Object.keys(store).forEach(key => {
-					keys += store[key];
-				});
+				Object.keys(store).forEach(() => (keys += 1));
 			});
 
 			effect(() => {
 				values = 0;
 				Object.values(store as RevertDeepSignal<typeof store>).forEach(
-					value => {
-						values += value;
-					}
+					() => (values += 1)
 				);
 			});
 
 			effect(() => {
 				entries = 0;
 				Object.entries(store as RevertDeepSignal<typeof store>).forEach(
-					([_, value]) => {
-						entries += value;
-					}
+					() => (entries += 1)
 				);
 			});
 
+			expect(keys).to.equal(2);
+			expect(values).to.equal(2);
+			expect(entries).to.equal(2);
+
+			store.c = 0;
 			expect(keys).to.equal(3);
 			expect(values).to.equal(3);
 			expect(entries).to.equal(3);
 
-			store.c = 3;
-			expect(keys).to.equal(6);
-			expect(values).to.equal(6);
-			expect(entries).to.equal(6);
-
 			delete store.a;
-			expect(keys).to.equal(5);
-			expect(values).to.equal(5);
-			expect(entries).to.equal(5);
+			expect(keys).to.equal(2);
+			expect(values).to.equal(2);
+			expect(entries).to.equal(2);
 		});
 
 		it("should subscribe to changes to for..of loops", () => {
-			const store = deepSignal([1, 2]);
+			const store = deepSignal([0, 0]);
 			let sum = 0;
 
 			effect(() => {
 				sum = 0;
-				for (const value of store) {
-					sum += value;
+				for (const _ of store) {
+					sum += 1;
 				}
 			});
 
+			expect(sum).to.equal(2);
+
+			store.push(0);
 			expect(sum).to.equal(3);
 
-			store.push(3);
-			expect(sum).to.equal(6);
-
 			store.splice(0, 1);
-			expect(sum).to.equal(5);
+			expect(sum).to.equal(2);
 		});
 
 		it("should subscribe to implicit changes in length", () => {

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -401,8 +401,11 @@ describe("deepsignal/core", () => {
 			store.c = 0;
 			expect(sum).to.equal(3);
 
-			delete store.a;
+			delete store.c;
 			expect(sum).to.equal(2);
+
+			store.c = 0;
+			expect(sum).to.equal(3);
 		});
 
 		it("should subscribe to changes for Object.getOwnPropertyNames()", () => {

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -326,7 +326,172 @@ describe("deepsignal/core", () => {
 		});
 	});
 
+	describe("ownKeys", () => {
+		it("should return own properties in objects", () => {
+			const state: Record<string, number> = { a: 1, b: 2 };
+			const store = deepSignal(state);
+			let sum = 0;
+
+			for (const property in store) {
+				sum += store[property];
+			}
+
+			expect(sum).to.equal(3);
+		});
+
+		it("should return own properties in arrays", () => {
+			const state: number[] = [1, 2];
+			const store = deepSignal(state);
+			let sum = 0;
+
+			for (const property of store) {
+				sum += property;
+			}
+
+			expect(sum).to.equal(3);
+		});
+
+		it("should spread objects correctly", () => {
+			const store2 = { ...store };
+			expect(store2.a).to.equal(1);
+			expect(store2.nested.b).to.equal(2);
+			expect(store2.array[0]).to.equal(3);
+			expect(typeof store2.array[1] === "object" && store2.array[1].b).to.equal(
+				2
+			);
+		});
+
+		it("should spread arrays correctly", () => {
+			const array2 = [...store.array];
+			expect(array2[0]).to.equal(3);
+			expect(typeof array2[1] === "object" && array2[1].b).to.equal(2);
+		});
+	});
+
 	describe("computations", () => {
+		it("should subscribe to changes to for..in loops", () => {
+			const state: Record<string, number> = { a: 1, b: 2 };
+			const store = deepSignal(state);
+			let sum = 0;
+
+			effect(() => {
+				sum = 0;
+				for (const key in store) {
+					sum += store[key];
+				}
+			});
+
+			expect(sum).to.equal(3);
+
+			store.c = 3;
+			expect(sum).to.equal(6);
+
+			delete store.a;
+			expect(sum).to.equal(5);
+		});
+
+		it("should subscribe to changes for Object.getOwnPropertyNames()", () => {
+			const state: Record<string, number> = { a: 1, b: 2 };
+			const store = deepSignal(state);
+			let sum = 0;
+
+			effect(() => {
+				sum = 0;
+				const keys = Object.getOwnPropertyNames(store);
+				for (const key of keys) {
+					sum += store[key];
+				}
+			});
+
+			expect(sum).to.equal(3);
+
+			store.c = 3;
+			expect(sum).to.equal(6);
+
+			delete store.a;
+			expect(sum).to.equal(5);
+		});
+
+		it("should subscribe to changes to Object.keys/values/entries()", () => {
+			const state: Record<string, number> = { a: 1, b: 2 };
+			const store = deepSignal(state);
+			let keys = 0;
+			let values = 0;
+			let entries = 0;
+
+			effect(() => {
+				keys = 0;
+				Object.keys(store).forEach(key => {
+					keys += store[key];
+				});
+			});
+
+			effect(() => {
+				values = 0;
+				Object.values(store as typeof state).forEach(value => {
+					values += value;
+				});
+			});
+
+			effect(() => {
+				entries = 0;
+				Object.entries(store as typeof state).forEach(([_, value]) => {
+					entries += value;
+				});
+			});
+
+			expect(keys).to.equal(3);
+			expect(values).to.equal(3);
+			expect(entries).to.equal(3);
+
+			store.c = 3;
+			expect(keys).to.equal(6);
+			expect(values).to.equal(6);
+			expect(entries).to.equal(6);
+
+			delete store.a;
+			expect(keys).to.equal(5);
+			expect(values).to.equal(5);
+			expect(entries).to.equal(5);
+		});
+
+		it("should subscribe to changes to for..of loops", () => {
+			const store = deepSignal([1, 2]);
+			let sum = 0;
+
+			effect(() => {
+				sum = 0;
+				for (const property of store) {
+					sum += !!property ? property : 0;
+				}
+			});
+
+			expect(sum).to.equal(3);
+
+			store.push(3);
+			expect(sum).to.equal(6);
+
+			store.splice(0, 1);
+			expect(sum).to.equal(5);
+		});
+
+		it("should subscribe to implicit changes in length", () => {
+			const store = deepSignal(["foo", "bar"]);
+			let x = "";
+
+			effect(() => {
+				x = store.join(" ");
+			});
+
+			expect(x).to.equal("foo bar");
+
+			store.push("baz");
+			expect(x).to.equal("foo bar baz");
+
+			store.splice(0, 1);
+			expect(x).to.equal("bar baz");
+		});
+
 		it("should subscribe to changes when deleting properties", () => {
 			let x, y;
 

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -370,6 +370,20 @@ describe("deepsignal/core", () => {
 	});
 
 	describe("computations", () => {
+		it("should subscribe to changes when an item is removed from the array", () => {
+			const store = deepSignal([1, 2, 3]);
+			let sum = 0;
+
+			effect(() => {
+				sum = 0;
+				sum = store.reduce((sum, item) => sum + item, 0);
+			});
+
+			expect(sum).to.equal(6);
+			store.splice(2, 1);
+			expect(sum).to.equal(3);
+		});
+
 		it("should subscribe to changes to for..in loops", () => {
 			const state: Record<string, number> = { a: 1, b: 2 };
 			const store = deepSignal(state);

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -323,7 +323,7 @@ describe("deepsignal/core", () => {
 		});
 
 		it("should throw when trying to delete the array signals", () => {
-			expect(() => delete store.array.$?.[1]).to.throw();
+			expect(() => delete store.array.$![1]).to.throw();
 		});
 	});
 
@@ -466,8 +466,8 @@ describe("deepsignal/core", () => {
 
 			effect(() => {
 				sum = 0;
-				for (const property of store) {
-					sum += !!property ? property : 0;
+				for (const value of store) {
+					sum += value;
 				}
 			});
 

--- a/packages/deepsignal/package.json
+++ b/packages/deepsignal/package.json
@@ -36,7 +36,10 @@
 			"browser": "./react/dist/deepsignal-react.module.js",
 			"import": "./react/dist/deepsignal-react.mjs",
 			"require": "./react/dist/deepsignal-react.js"
-		}
+		},
+		"./package.json": "./package.json",
+		"./core/package.json": "./core/package.json",
+		"./react/package.json": "./react/package.json"
 	},
 	"scripts": {
 		"prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build"


### PR DESCRIPTION
## What

Add support for the `ownKeys` trap, which is used with `for..in`, `getOwnPropertyNames` or `Object.keys/values/entries`.

- I also exported the `RevertDeepSignal` type which is useful when using `Object.values()`.
- I also added some missing tests for similar array subscriptions, although those where working fine because they access `array.length` and we were already updating that signal when items are added or removed from the array.

## Why

To be able to subscribe when properties are added or removed from objects.

```js
const store = deepSignal({ a: 1 });

effect(() => {
  for (const key in store) {
    console.log(`${key}: ${store[key]}`);
  }
});

store.b = 2; // console.logs `a: 1` and `b: 2`
```

## How

I added a new map that stores a fake signal for each object. When `ownKeys` is accessed, the computations are subscribed to that signal. When a property is added or removed from the object, we update the signal to retrigger the subscribed computations.