### PR TITLE
Fix production build

### DIFF
--- a/.changeset/chilled-rivers-march.md
+++ b/.changeset/chilled-rivers-march.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Fix production tests and a couple of problems in production with `peek` and the `ownKeys` trap.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -83,7 +83,7 @@ function createEsbuildPlugin() {
 
 			// Aliasing: If "MINIFY" is set to "true" we use the dist/
 			// files instead of those from src/
-			build.onResolve({ filter: /^@preact\/.*/ }, args => {
+			build.onResolve({ filter: /^deepsignal\/.*/ }, args => {
 				const pkg = alias[args.path];
 				return {
 					path: pkg,

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -115,7 +115,7 @@ const objectHandlers = {
 	},
 	ownKeys(target: object): (string | symbol)[] {
 		if (!objToIterable.has(target)) objToIterable.set(target, signal(0));
-		objToIterable.get(target).value;
+		objToIterable.get(target).value = objToIterable.get(target).value;
 		return Reflect.ownKeys(target);
 	},
 };

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -24,7 +24,9 @@ export const peek = <
 ): RevertDeepSignal<RevertDeepSignalObject<T>[K]> => {
 	peeking = true;
 	const value = obj[key];
-	peeking = false;
+	try {
+		peeking = false;
+	} catch (e) {}
 	return value as RevertDeepSignal<RevertDeepSignalObject<T>[K]>;
 };
 


### PR DESCRIPTION
## What

1. Fix the production tests, which were not passing correctly
1. Fix the `ownKeys` trap, which was not working in production
1. Fix the `peek` function, which was not working in production

## Why

Because the production tests were broken.

## How

1. Filter correctly the `deepsignal` packages in Karma.
1. Reassing the value to itself to prevent the JS minifier from removing the `.value` access.
1. Wrap the last flag in a `try/catch` to prevent the JS minifier from reordering the assignments.
