### PR TITLE
Use `@preact/signals` dependencies as peer dependencies

### DIFF
--- a/.changeset/rude-llamas-develop.md
+++ b/.changeset/rude-llamas-develop.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Use `@preact/signals` dependencies as peer dependencies.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,13 @@ The most important feature is that **it just works**. You don't need to do anyth
 
 ## Installation
 
+### With Preact
+
 ```sh
-npm install deepsignal
+npm install deepsignal @preact/signals
 ```
 
-If you are using `deepsignal` with Preact (`@preact/signals`), you should use the `deepsignal` import. You don't need to install or import `@preact/signals` anywhere in your code if you don't need it.
+If you are using `deepsignal` with Preact (`@preact/signals`), you should use the `deepsignal` import. You also need to install `@preact/signals`.
 
 ```js
 import { deepSignal } from "deepsignal";
@@ -73,7 +75,11 @@ const state = deepSignal({});
 
 ### With React
 
-If you are using the library with React, you should use the `deepsignal/react` import. You don't need to install or import `@preact/signals-react` anywhere in your code if you don't need it.
+```sh
+npm install deepsignal @preact/signals-react
+```
+
+If you are using the library with React, you should use the `deepsignal/react` import. You also need to install `@preact/signals-react`.
 
 ```js
 import { deepSignal } from "deepsignal/react";
@@ -83,7 +89,11 @@ const state = deepSignal({});
 
 ### Without Preact/React
 
-If you are using the library just with `@preact/signals-core`, you should use the `deepsignal/core` import.
+```sh
+npm install deepsignal @preact/signals-core
+```
+
+If you are using the library just with `@preact/signals-core`, you should use the `deepsignal/core` import. You also need to install `@preact/signals-core`.
 
 ```js
 import { deepSignal } from "deepsignal/core";

--- a/packages/deepsignal/package.json
+++ b/packages/deepsignal/package.json
@@ -44,17 +44,17 @@
 	"scripts": {
 		"prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"@preact/signals-core": "^1.3.1",
 		"@preact/signals": "^1.1.4",
 		"@preact/signals-react": "^1.3.3"
 	},
-	"peerDependencies": {
-		"preact": "10.x"
-	},
 	"devDependencies": {
 		"preact": "10.9.0",
 		"preact-render-to-string": "^5.2.4",
+		"@preact/signals-core": "^1.3.1",
+		"@preact/signals": "^1.1.4",
+		"@preact/signals-react": "^1.3.3",
 		"@types/react": "^18.0.18",
 		"@types/react-dom": "^18.0.6",
 		"react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 4.7.4
 
   packages/deepsignal:
-    dependencies:
+    devDependencies:
       '@preact/signals':
         specifier: ^1.1.4
         version: 1.1.4(preact@10.9.0)
@@ -148,7 +148,6 @@ importers:
       '@preact/signals-react':
         specifier: ^1.3.3
         version: 1.3.3(react@18.2.0)
-    devDependencies:
       '@types/react':
         specifier: ^18.0.18
         version: 18.0.27
@@ -1900,7 +1899,7 @@ packages:
 
   /@preact/signals-core@1.3.1:
     resolution: {integrity: sha512-DL+3kDssZ3UOMz9HufwSYE/gK0+TnT1jzegfF5rstgyPrnyfjz4BHAoxmzQA6Mkp4UlKe8qjsgl3v5a/obzNig==}
-    dev: false
+    dev: true
 
   /@preact/signals-react@1.3.3(react@18.2.0):
     resolution: {integrity: sha512-Tbv+oWPcrWowAJp1U1eWFiFUJihulOAnL8g/hJ3fUsP0IcsKsj8U0OcIDrwemIPQe7+J/3FuudkZzted0MD/bA==}
@@ -1910,7 +1909,7 @@ packages:
       '@preact/signals-core': 1.3.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
-    dev: false
+    dev: true
 
   /@preact/signals@1.1.4(preact@10.9.0):
     resolution: {integrity: sha512-4s0U8yHfy6OzBjTx8lgG0JZGFq1y+ye7xLmaaI8SXyJ5p+jAtMKW40Mg3GDLISM5WyKnqbfrQ4SOmbq1VTBtTw==}
@@ -1919,7 +1918,7 @@ packages:
     dependencies:
       '@preact/signals-core': 1.3.1
       preact: 10.9.0
-    dev: false
+    dev: true
 
   /@rollup/plugin-alias@3.1.9(rollup@2.77.2):
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
@@ -4577,6 +4576,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -4926,6 +4926,7 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: true
 
   /loupe@2.3.4:
     resolution: {integrity: sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==}
@@ -5930,6 +5931,7 @@ packages:
 
   /preact@10.9.0:
     resolution: {integrity: sha512-jO6/OvCRL+OT8gst/+Q2ir7dMybZAX8ioP02Zmzh3BkQMHLyqZSujvxbUriXvHi8qmhcHKC2Gwbog6Kt+YTh+Q==}
+    dev: true
 
   /preferred-pm@3.0.3:
     resolution: {integrity: sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==}
@@ -6045,6 +6047,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: true
 
   /read-pkg-up@7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -6995,7 +6998,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
-    dev: false
+    dev: true
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}


### PR DESCRIPTION
## What

Use `@preact/signals` dependencies as peer dependencies.

Fixes https://github.com/luisherranz/deepsignal/issues/39.

## Why

Because it's probably better to let users install the correct `@preact/signals` version manually, instead of manually installing all of them. In addition, it was causing problems with peer dependencies (https://github.com/luisherranz/deepsignal/issues/39).

## How

Just move them from `dependencies` to `peerDependencies`.