### PR TITLE
Add `preact` as peer dependency back and mark them as optional

### DIFF
--- a/.changeset/smart-clocks-dance.md
+++ b/.changeset/smart-clocks-dance.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": patch
+---
+
+Add `preact` as peer dependency back.

--- a/.changeset/smart-clocks-dance.md
+++ b/.changeset/smart-clocks-dance.md
@@ -2,4 +2,4 @@
 "deepsignal": patch
 ---
 
-Add `preact` as peer dependency back.
+Add `preact` as peer dependency back and mark them as optional.

--- a/packages/deepsignal/package.json
+++ b/packages/deepsignal/package.json
@@ -50,6 +50,20 @@
 		"@preact/signals-react": "^1.3.3",
 		"preact": "^10.16.0"
 	},
+	"peerDependenciesMeta": {
+		"@preact/signals-core": {
+			"optional": true
+		},
+		"@preact/signals": {
+			"optional": true
+		},
+		"@preact/signals-react": {
+			"optional": true
+		},
+		"preact": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"preact": "10.9.0",
 		"preact-render-to-string": "^5.2.4",

--- a/packages/deepsignal/package.json
+++ b/packages/deepsignal/package.json
@@ -47,7 +47,8 @@
 	"peerDependencies": {
 		"@preact/signals-core": "^1.3.1",
 		"@preact/signals": "^1.1.4",
-		"@preact/signals-react": "^1.3.3"
+		"@preact/signals-react": "^1.3.3",
+		"preact": "^10.16.0"
 	},
 	"devDependencies": {
 		"preact": "10.9.0",


### PR DESCRIPTION
## What

Add `preact` as peer dependency again and mark them as optional.

## Why

Because I removed it when on the [last PR](https://github.com/luisherranz/deepsignal/pull/40) and it was included in the final bundle.

## How

Add `preact` again to the list of peer dependencies. Additionally, I've added the `"optional"` meta to all of them, to see if that helps avoiding errors when the packages are not installed.
