### PR TITLE
Prevent any type of class instances

### DIFF
--- a/.changeset/pretty-files-visit.md
+++ b/.changeset/pretty-files-visit.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": major
+---
+
+Remove support for class instances and everything that is not strictly plain objects or arrays.

--- a/.changeset/pretty-files-visit.md
+++ b/.changeset/pretty-files-visit.md
@@ -1,5 +1,5 @@
 ---
-"deepsignal": major
+"deepsignal": patch
 ---
 
-Remove support for class instances and everything that is not strictly plain objects or arrays.
+Reject class instances and everything that is not strictly plain objects or arrays.

--- a/packages/deepsignal/core/src/index.ts
+++ b/packages/deepsignal/core/src/index.ts
@@ -149,11 +149,7 @@ const wellKnownSymbols = new Set(
 const supported = new Set([Object, Array]);
 const shouldProxy = (val: any): boolean => {
 	if (typeof val !== "object" || val === null) return false;
-	const isBuiltIn =
-		typeof val.constructor === "function" &&
-		val.constructor.name in globalThis &&
-		(globalThis as any)[val.constructor.name] === val.constructor;
-	return (!isBuiltIn || supported.has(val.constructor)) && !ignore.has(val);
+	return supported.has(val.constructor) && !ignore.has(val);
 };
 
 /** TYPES **/

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -874,11 +874,18 @@ describe("deepsignal/core", () => {
 		});
 	});
 
-	describe("built-ins", () => {
-		it("should throw when trying to deepsignal a built-in", () => {
-			window.MyClass = class MyClass {};
-			const obj = new window.MyClass();
+	describe("unsupported data structures", () => {
+		it("should throw when trying to deepsignal a class instance", () => {
+			class MyClass {}
+			const obj = new MyClass();
 			expect(() => deepSignal(obj)).to.throw();
+		});
+
+		it("should not wrap a class instance", () => {
+			class MyClass {}
+			const obj = new MyClass();
+			const store = deepSignal({ obj });
+			expect(store.obj).to.equal(obj);
 		});
 
 		it("should not wrap built-ins in proxies", () => {
@@ -903,19 +910,19 @@ describe("deepsignal/core", () => {
 			expect(store.$b.value).to.equal(2);
 		});
 
-		it("should not wrap Date", () => {
+		it("should not wrap dates", () => {
 			const date = new Date();
 			const store = deepSignal({ date });
 			expect(store.date).to.equal(date);
 		});
 
-		it("should not wrap RegExp", () => {
+		it("should not wrap regular expressions", () => {
 			const regex = new RegExp("");
 			const store = deepSignal({ regex });
 			expect(store.regex).to.equal(regex);
 		});
 
-		it("should not wrap Maps", () => {
+		it("should not wrap Map", () => {
 			const map = new Map();
 			const store = deepSignal({ map });
 			expect(store.map).to.equal(map);
@@ -925,13 +932,6 @@ describe("deepsignal/core", () => {
 			const set = new Set();
 			const store = deepSignal({ set });
 			expect(store.set).to.equal(set);
-		});
-
-		it("should not wrap built-ins in proxies", () => {
-			window.MyClass = class MyClass {};
-			const obj = new window.MyClass();
-			const store = deepSignal({ obj });
-			expect(store.obj).to.equal(obj);
 		});
 	});
 


### PR DESCRIPTION
## What

This is built on top of https://github.com/luisherranz/deepsignal/pull/38.

Prevent wrapping class instances and everything that is not strictly plain objects or arrays.

## Why

I'd like to try to keep the library as simple as possible and see if supporting only plain objects and array fulfills its state management purpose. If it doesn't, I may try to include support again in the future.

## How

By not wrapping anything that doesn't have an `Object` or `Array` constructor.