### PR TITLE
Add docs and tests to show how to reset a store to some initial values

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
     - [`peek(state, "prop")`](#peekstate-prop)
     - [`state.$prop = signal(value)`](#stateprop--signalvalue)
     - [`useDeepSignal`](#usedeepsignal)
+  - [Common Patterns](#common-patterns)
+    - [Resetting the store](#resetting-the-store)
   - [When do you need access to signals?](#when-do-you-need-access-to-signals)
     - [Passing the value of a signal directly to JSX](#passing-the-value-of-a-signal-directly-to-jsx)
     - [Passing a signal to a child component](#passing-a-signal-to-a-child-component)
@@ -47,7 +49,7 @@ Use [Preact signals](https://github.com/preactjs/signals) with the interface of 
 
 ## Features
 
-- **Transparent**: `deepsignal` wraps the objects with proxies that intercept all property accesses, but does not modify the object. This means that you can still use the object as you normally would, and it will behave exactly as expected. Mutating the object updates the value of the underlying signals.
+- **Transparent**: `deepsignal` wraps the object with a proxy that intercepts all property accesses, but does not modify how you interact with the object. This means that you can still use the object as you normally would, and it will behave exactly as you would expect, except that mutating the object also updates the value of the underlying signals.
 - **Tiny (less than 1kB)**: `deepsignal` is designed to be lightweight and has a minimal footprint, making it easy to include in your projects. It's just a small wrapper around `@preact/signals-core`.
 - **Full array support**: `deepsignal` fully supports arrays, including nested arrays.
 - **Deep**: `deepsignal` converts nested objects and arrays to deep signal objects/arrays, allowing you to create fully reactive data structures.
@@ -308,7 +310,7 @@ _For primitive values, you can get away with using `store.$prop.peek()` instead 
 
 ### `state.$prop = signal(value)`
 
-You can modify the underlying signal of an object's property doing an assignment to the `$`-prefixed name.
+You can modify the underlying signal of an object's property by doing an assignment to the `$`-prefixed name.
 
 ```js
 const state = deepSignal({ counter: 0 });
@@ -349,6 +351,28 @@ function Counter() {
 	);
 }
 ```
+
+## Common Patterns
+
+### Resetting the store
+
+If you need to reset your store to some initial values, don't overwrite the reference. Instead, replace each value using something like `Object.assign`.
+
+```js
+const initialState = { counter: 0 };
+
+const store = deepSignal({
+	...initialState,
+	inc: () => {
+		store.counter++;
+	},
+	reset: () => {
+		Object.assign(store, initialState);
+	},
+});
+```
+
+Take into account that the object that you pass to `deepSignal` during the creation is also mutated when you mutate the deep signal. Therefore, if you need to keep a set of initial values, you need to store them in a different object or clone it before assigning it to the deepsignal.
 
 ## When do you need access to signals?
 
@@ -448,7 +472,7 @@ You can use the `DeepSignal` type if you want to declare your type instead of in
 import type { DeepSignal } from "deepsignal";
 
 type Store = DeepSignal<{
-  counter: boolean;
+	counter: boolean;
 }>;
 
 const store = deepSignal<Store>({ counter: 0 });
@@ -456,7 +480,7 @@ const store = deepSignal<Store>({ counter: 0 });
 
 ### RevertDeepSignal
 
-You can use the `RevertDeepSignal` type if you want to recover the type of the plain object/array using the type of the `deepSignal` instance, like for example when you need to use `Object.values()`.
+You can use the `RevertDeepSignal` type if you want to recover the type of the plain object/array using the type of the `deepSignal` instance. For example, when you need to use `Object.values()`.
 
 ```ts
 import type { RevertDeepSignal } from "deepsignal";

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -296,6 +296,16 @@ describe("deepsignal/core", () => {
 			expect(store.a.nested.id).to.equal(4);
 			expect(store.b.nested.id).to.equal(4);
 		});
+
+		it.only("should be able to reset values with Object.assign", () => {
+			const initialNested = { ...nested };
+			const initialState = { ...state, nested: initialNested };
+			store.a = 2;
+			store.nested.b = 3;
+			Object.assign(store, initialState);
+			expect(store.a).to.equal(1);
+			expect(store.nested.b).to.equal(2);
+		});
 	});
 
 	describe("delete", () => {

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -764,6 +764,30 @@ describe("deepsignal/core", () => {
 			expect(spy1).callCount(4);
 			expect(spy2).callCount(4);
 		});
+
+		it("should be able to reset values with Object.assign and still react to changes", () => {
+			const initialNested = { ...nested };
+			const initialState = { ...state, nested: initialNested };
+			let a, b;
+
+			effect(() => {
+				a = store.a;
+			});
+			effect(() => {
+				b = store.nested.b;
+			});
+
+			store.a = 2;
+			store.nested.b = 3;
+
+			expect(a).to.equal(2);
+			expect(b).to.equal(3);
+
+			Object.assign(store, initialState);
+
+			expect(a).to.equal(1);
+			expect(b).to.equal(2);
+		});
 	});
 
 	describe("peek", () => {

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -297,7 +297,7 @@ describe("deepsignal/core", () => {
 			expect(store.b.nested.id).to.equal(4);
 		});
 
-		it.only("should be able to reset values with Object.assign", () => {
+		it("should be able to reset values with Object.assign", () => {
 			const initialNested = { ...nested };
 			const initialState = { ...state, nested: initialNested };
 			store.a = 2;


### PR DESCRIPTION
## What

Add docs section and tests to show how to reset a store to some initial values.

## Why

Because it may not be immediately obvious: https://github.com/luisherranz/deepsignal/issues/49

## How

Just adding a new "Common Patterns" section in the docs, and adding a couple of tests to make sure that doing `Object.assign` in the deep signal works as expected.

There's no need for a changeset here because the code didn't change.