### PR TITLE
Support @preact/signals-react 2

### DIFF
--- a/.changeset/strong-adults-march.md
+++ b/.changeset/strong-adults-march.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": minor
+---
+
+Add a peer dependency for @preact/signals-react 2.0.0

--- a/.changeset/strong-adults-march.md
+++ b/.changeset/strong-adults-march.md
@@ -2,4 +2,4 @@
 "deepsignal": minor
 ---
 
-Add a peer dependency for @preact/signals-react 2.0.0
+Add support for @preact/signals-react 2.0.0

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ import { deepSignal } from "deepsignal/react";
 const state = deepSignal({});
 ```
 
-Starting from `@preact/signals-react@2.0.0`, you should also follow the [React integration guide of `@preact/signals-react`](https://github.com/preactjs/signals/blob/main/packages/react/README.md#react-integration) to choose one of the integration methods.
+- If you want to use `deepSignal` outside of the components, please follow the [React integration guide of `@preact/signals-react`](https://github.com/preactjs/signals/blob/main/packages/react/README.md#react-integration) to choose one of the integration methods.
+- If rely exclusively on `useDeepSignal`, no integration is required.
 
 ### Without Preact/React
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ import { deepSignal } from "deepsignal/react";
 const state = deepSignal({});
 ```
 
+Starting from `@preact/signals-react@2.0.0`, you should also follow the [React integration guide of `@preact/signals-react`](https://github.com/preactjs/signals/blob/main/packages/react/README.md#react-integration) to choose one of the integration methods.
+
 ### Without Preact/React
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ const state = deepSignal({});
 ```
 
 - If you want to use `deepSignal` outside of the components, please follow the [React integration guide of `@preact/signals-react`](https://github.com/preactjs/signals/blob/main/packages/react/README.md#react-integration) to choose one of the integration methods.
-- If rely exclusively on `useDeepSignal`, no integration is required.
+- For `useDeepSignal`, no integration is required.
 
 ### Without Preact/React
 

--- a/packages/deepsignal/package.json
+++ b/packages/deepsignal/package.json
@@ -45,9 +45,9 @@
 		"prepublishOnly": "cp ../../README.md . && cd ../.. && pnpm build"
 	},
 	"peerDependencies": {
-		"@preact/signals-core": "^1.3.1",
+		"@preact/signals-core": "^1.5.1",
 		"@preact/signals": "^1.1.4",
-		"@preact/signals-react": "^1.3.3",
+		"@preact/signals-react": "^1.3.8 || ^2.0.0",
 		"preact": "^10.16.0"
 	},
 	"peerDependenciesMeta": {
@@ -67,9 +67,9 @@
 	"devDependencies": {
 		"preact": "10.9.0",
 		"preact-render-to-string": "^5.2.4",
-		"@preact/signals-core": "^1.3.1",
+		"@preact/signals-core": "^1.5.1",
 		"@preact/signals": "^1.1.4",
-		"@preact/signals-react": "^1.3.3",
+		"@preact/signals-react": "^2.0.0",
 		"@types/react": "^18.0.18",
 		"@types/react-dom": "^18.0.6",
 		"react": "^18.2.0",

--- a/packages/deepsignal/react/package.json
+++ b/packages/deepsignal/react/package.json
@@ -9,8 +9,8 @@
 	"source": "src/index.ts",
 	"license": "MIT",
 	"dependencies": {
-		"@preact/signals-core": "^1.3.1",
-		"@preact/signals-react": "^1.3.3"
+		"@preact/signals-core": "^1.5.1",
+		"@preact/signals-react": "^2.0.0"
 	},
 	"peerDependencies": {
 		"react": "17.x || 18.x"

--- a/packages/deepsignal/react/src/index.ts
+++ b/packages/deepsignal/react/src/index.ts
@@ -1,8 +1,10 @@
 import "@preact/signals-react";
 import { useMemo } from "react";
 import { deepSignal, type DeepSignal } from "../../core/src";
+import { useSignals } from "@preact/signals-react/runtime";
 
 export const useDeepSignal = <T extends object>(obj: T): DeepSignal<T> => {
+	useSignals();
 	return useMemo(() => deepSignal(obj), []);
 };
 

--- a/packages/deepsignal/react/test/index.test.tsx
+++ b/packages/deepsignal/react/test/index.test.tsx
@@ -6,24 +6,28 @@ import { createElement } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { useDeepSignal, type DeepSignal } from "deepsignal/react";
-import "@preact/signals/auto";
 
 describe("deepsignal/react", () => {
 	let scratch: HTMLDivElement;
 	let root: Root;
-	function render(element: Parameters<Root["render"]>[0]) {
-		act(() => root.render(element));
-	}
+	let render: Root["render"];
 
-	const window = globalThis as any;
+	beforeEach(async () => {
+		scratch = document.createElement("div");
+		document.body.appendChild(scratch);
 
-	beforeEach(() => {
-		scratch = window.document.createElement("div");
-		root = createRoot(scratch);
+		const realRoot = createRoot(scratch);
+		root = {
+			render: element => act(() => realRoot.render(element)),
+			unmount: () => act(() => realRoot.unmount()),
+		};
+
+		render = root.render.bind(root);
 	});
 
 	afterEach(() => {
 		act(() => root.unmount());
+		scratch.remove();
 	});
 
 	describe("useDeepSignal", () => {
@@ -38,7 +42,7 @@ describe("deepsignal/react", () => {
 			}
 
 			// @ts-ignore
-			render(<App />);
+			await render(<App />);
 
 			expect(scratch.textContent).to.equal("test");
 			expect(spy).to.be.calledOnce;

--- a/packages/deepsignal/react/test/index.test.tsx
+++ b/packages/deepsignal/react/test/index.test.tsx
@@ -6,6 +6,7 @@ import { createElement } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { useDeepSignal, type DeepSignal } from "deepsignal/react";
+import "@preact/signals/auto";
 
 describe("deepsignal/react", () => {
 	let scratch: HTMLDivElement;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,11 +143,11 @@ importers:
         specifier: ^1.1.4
         version: 1.1.4(preact@10.9.0)
       '@preact/signals-core':
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.5.1
+        version: 1.5.1
       '@preact/signals-react':
-        specifier: ^1.3.3
-        version: 1.3.3(react@18.2.0)
+        specifier: ^2.0.0
+        version: 2.0.0(react@18.2.0)
       '@types/react':
         specifier: ^18.0.18
         version: 18.0.27
@@ -1897,16 +1897,16 @@ packages:
       fastq: 1.13.0
     dev: true
 
-  /@preact/signals-core@1.3.1:
-    resolution: {integrity: sha512-DL+3kDssZ3UOMz9HufwSYE/gK0+TnT1jzegfF5rstgyPrnyfjz4BHAoxmzQA6Mkp4UlKe8qjsgl3v5a/obzNig==}
+  /@preact/signals-core@1.5.1:
+    resolution: {integrity: sha512-dE6f+WCX5ZUDwXzUIWNMhhglmuLpqJhuy3X3xHrhZYI0Hm2LyQwOu0l9mdPiWrVNsE+Q7txOnJPgtIqHCYoBVA==}
     dev: true
 
-  /@preact/signals-react@1.3.3(react@18.2.0):
-    resolution: {integrity: sha512-Tbv+oWPcrWowAJp1U1eWFiFUJihulOAnL8g/hJ3fUsP0IcsKsj8U0OcIDrwemIPQe7+J/3FuudkZzted0MD/bA==}
+  /@preact/signals-react@2.0.0(react@18.2.0):
+    resolution: {integrity: sha512-tMVi2SXFXlojaiPNWa8dlYaidR/XvEgMSp+iymKJgMssBM/QVtUQrodKZek1BJju+dkVHiyeuQHmkuLOI9oyNw==}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x
     dependencies:
-      '@preact/signals-core': 1.3.1
+      '@preact/signals-core': 1.5.1
       react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: true
@@ -1916,7 +1916,7 @@ packages:
     peerDependencies:
       preact: 10.x
     dependencies:
-      '@preact/signals-core': 1.3.1
+      '@preact/signals-core': 1.5.1
       preact: 10.9.0
     dev: true
 


### PR DESCRIPTION
## What

This PR adds support for `@preact/signals-react` v2.

## Why

Because the Preact team has changed how `@preact/signals-react` is integrated with React and released a new major version.

## How

By updating the tests, readme, peer dependencies, and `useDeepSignal`.

