### PR TITLE
Support setters

### DIFF
--- a/.changeset/hot-ties-play.md
+++ b/.changeset/hot-ties-play.md
@@ -1,0 +1,5 @@
+---
+"deepsignal": minor
+---
+
+Add support for setters.

--- a/packages/deepsignal/core/test/index.test.tsx
+++ b/packages/deepsignal/core/test/index.test.tsx
@@ -189,6 +189,21 @@ describe("deepsignal/core", () => {
 			expect(store.nested.b).to.equal(3);
 		});
 
+		it("should support setting values with setters", () => {
+			const store = deepSignal({
+				counter: 1,
+				get double() {
+					return store.counter * 2;
+				},
+				set double(val) {
+					store.counter = val / 2;
+				},
+			});
+			expect(store.counter).to.equal(1);
+			store.double = 4;
+			expect(store.counter).to.equal(2);
+		});
+
 		it("should update array length", () => {
 			expect(store.array.length).to.equal(2);
 			store.array.push(4);
@@ -394,6 +409,31 @@ describe("deepsignal/core", () => {
 	});
 
 	describe("computations", () => {
+		it("should subscribe to values mutated with setters", () => {
+			const store = deepSignal({
+				counter: 1,
+				get double() {
+					return store.counter * 2;
+				},
+				set double(val) {
+					store.counter = val / 2;
+				},
+			});
+			let counter = 0;
+			let double = 0;
+
+			effect(() => {
+				counter = store.counter;
+				double = store.double;
+			});
+
+			expect(counter).to.equal(1);
+			expect(double).to.equal(2);
+			store.double = 4;
+			expect(counter).to.equal(2);
+			expect(double).to.equal(4);
+		});
+
 		it("should subscribe to changes when an item is removed from the array", () => {
 			const store = deepSignal([0, 0, 0]);
 			let sum = 0;


### PR DESCRIPTION
## What

Fixes https://github.com/luisherranz/deepsignal/issues/47.

Adds support for setters, like:

```js
const store = deepSignal({
  counter: 1,
  get double() {
    return store.counter * 2;
  },
  set double(val) {
    store.counter = val / 2;
  },
});

store.counter // 1

store.double = 4;

store.counter // 2
```

## Why

Because setters are useful.

## How

By shortcircuiting the `set` handler when the property has a setter.